### PR TITLE
Capy 240: protect backend routes

### DIFF
--- a/app/backend/user/pom.xml
+++ b/app/backend/user/pom.xml
@@ -33,6 +33,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/app/backend/user/src/main/java/de/capyclue/user/controller/UserController.java
+++ b/app/backend/user/src/main/java/de/capyclue/user/controller/UserController.java
@@ -4,10 +4,8 @@ import de.capyclue.user.model.User;
 import de.capyclue.user.service.IUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,19 +24,16 @@ public class UserController {
         return "hello world, this is the user microservice";
     }
 
-    @GetMapping(path = "/users")
-    public List<User> getAllUsers(){
-        return userService.getAllUsers();
-    }
-
-    @GetMapping(path = "/user/{id}")
-    public User getUserById(@PathVariable Long id){
-        return new User();
-    }
-
-    @GetMapping(path="/testauth")
-    public String testAuth(){
-        return "hello world, this is a protected route of the user microservice";
+    @GetMapping(path = "/user")
+    public User getUserByAuth0Token(Authentication authentication){
+        String auth0UserId = authentication.getName();
+        System.out.println("auth0UserId: " + auth0UserId);
+        User user = new User();
+        user.setId(1L);
+        user.setFirstName("Max");
+        user.setLastName("Mustermann");
+        user.setEmail("max.mushter@email.de");
+        return user;
     }
 
 }

--- a/app/backend/user/src/main/java/de/capyclue/user/controller/UserController.java
+++ b/app/backend/user/src/main/java/de/capyclue/user/controller/UserController.java
@@ -36,4 +36,9 @@ public class UserController {
         return new User();
     }
 
+    @GetMapping(path="/testauth")
+    public String testAuth(){
+        return "hello world, this is a protected route of the user microservice";
+    }
+
 }

--- a/app/backend/user/src/main/java/de/capyclue/user/security/SecurityConfig.java
+++ b/app/backend/user/src/main/java/de/capyclue/user/security/SecurityConfig.java
@@ -1,20 +1,37 @@
 package de.capyclue.user.security;
 
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
 
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    private final Environment environment;
+
+    public SecurityConfig(Environment environment) {
+        this.environment = environment;
+    }
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
             .authorizeRequests()
-                .antMatchers("/api/user/testauth").authenticated()
+                .antMatchers("/api/user/user").authenticated()
                 .anyRequest().permitAll()
                 .and()
             .oauth2ResourceServer()
-                .jwt();
+                .jwt().decoder(jwtDecoder());
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder() {
+        String issuerUri = environment.getProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri");
+        assert issuerUri != null;
+        return JwtDecoders.fromIssuerLocation(issuerUri);
     }
 
 }

--- a/app/backend/user/src/main/java/de/capyclue/user/security/SecurityConfig.java
+++ b/app/backend/user/src/main/java/de/capyclue/user/security/SecurityConfig.java
@@ -1,0 +1,20 @@
+package de.capyclue.user.security;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+            .authorizeRequests()
+                .antMatchers("/api/user/testauth").authenticated()
+                .anyRequest().permitAll()
+                .and()
+            .oauth2ResourceServer()
+                .jwt();
+    }
+
+}

--- a/app/backend/user/src/main/resources/application.properties
+++ b/app/backend/user/src/main/resources/application.properties
@@ -2,6 +2,6 @@ spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 spring.datasource.url=jdbc:mariadb://localhost:3306/dhbwcd_user
 spring.datasource.username=dummyuser
 spring.datasource.password=dummypassword
-auth0.audience=/api/user/
+auth0.audience=https://dhbwcd-dev.mush-it.com/api/
 auth0.domain=dhbwcd.eu.auth0.com
 spring.security.oauth2.resourceserver.jwt.issuer-uri=https://${auth0.domain}/

--- a/app/backend/user/src/main/resources/application.properties
+++ b/app/backend/user/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.datasource.url=jdbc:mariadb://localhost:3306/dhbwcd_user
+spring.datasource.url=jdbc:mariadb://database-user:3306/dhbwcd_user
 spring.datasource.username=dummyuser
 spring.datasource.password=dummypassword
 auth0.audience=https://dhbwcd-dev.mush-it.com/api/

--- a/app/backend/user/src/main/resources/application.properties
+++ b/app/backend/user/src/main/resources/application.properties
@@ -1,4 +1,7 @@
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.datasource.url=jdbc:mariadb://database-user:3306/dhbwcd_user
+spring.datasource.url=jdbc:mariadb://localhost:3306/dhbwcd_user
 spring.datasource.username=dummyuser
 spring.datasource.password=dummypassword
+auth0.audience=/api/user/
+auth0.domain=dhbwcd.eu.auth0.com
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://${auth0.domain}/

--- a/app/frontend/src/components/auth/LogInLogOutStatus.js
+++ b/app/frontend/src/components/auth/LogInLogOutStatus.js
@@ -2,9 +2,9 @@ import Button from 'react-bootstrap/Button';
 import { useAuth0 } from '@auth0/auth0-react';
 
 function LogInLogOutStatus() {
-    const { user, loginWithRedirect, logout } = useAuth0();
+    const { user, loginWithRedirect, logout, isAuthenticated } = useAuth0();
     return (
-        (user) ? 
+        (isAuthenticated) ? 
         (
             <>
                 <p>Eingeloggt als {user.nickname}</p>

--- a/app/frontend/src/components/settings/Settings.js
+++ b/app/frontend/src/components/settings/Settings.js
@@ -1,3 +1,7 @@
+import React, { useState, useEffect } from 'react';
+import { useAuth0 } from "@auth0/auth0-react";
+import { baseUrlUser } from '../../config';
+
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Nav from 'react-bootstrap/Nav';
@@ -10,6 +14,25 @@ import GeneralSettings from './GeneralSettings';
 import AboutSettings from './AboutSettings';
 
 function Settings() {
+    const { user, isAuthenticated, getAccessTokenSilently} = useAuth0();
+    const [userData, setUserData] = useState({});
+    useEffect(() => {
+        if (!isAuthenticated) {
+            return;
+        }
+        (async () => {
+        let token = await getAccessTokenSilently();
+        const response = await fetch(baseUrlUser+'/user/', {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+        let data = await response.json();
+        setUserData(data);
+        })();
+    }, [getAccessTokenSilently, isAuthenticated]);
+
+
     return(
         <>
         <Tab.Container defaultActiveKey="account">

--- a/app/frontend/src/config.js
+++ b/app/frontend/src/config.js
@@ -1,5 +1,7 @@
 export const baseUrlAuth        = 'dhbwcd.eu.auth0.com';
 export const clientId           = 'u9WC2q19RpHlMilbAxlyYihN02b1WBSg';
+export const audience           = 'https://dhbwcd-dev.mush-it.com/api/';
+
 export const baseUrlUser        = '/api/user'       //'http://localhost:8080/api/user';
 export const baseUrlCalendar    = '/api/calendar'   //'http://localhost:8081/api/calendar';
 export const baseUrlCanteen     = '/api/canteen'    //'http://localhost:8082/api/canteen';

--- a/app/frontend/src/index.js
+++ b/app/frontend/src/index.js
@@ -4,7 +4,7 @@ import './index.css';
 import App from './App';
 import { Auth0Provider } from "@auth0/auth0-react";
 import reportWebVitals from './reportWebVitals';
-import { baseUrlAuth, clientId } from './config';
+import { baseUrlAuth, clientId, audience } from './config';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 
@@ -15,7 +15,8 @@ root.render(
     domain={baseUrlAuth}
     clientId={clientId}
     authorizationParams={{
-      redirect_uri: window.location.origin
+      redirect_uri: window.location.origin,
+      audience: audience,
     }}
   >
     <App />


### PR DESCRIPTION
I implemented:
- working authentication workflow between frontend and backend
- A request to "api/user/user" that should in future return the user data (from our db) of the current user.
- Backend logic to protect the GET "api/user/user" route.
- Backend logic to extract the user_id (as auth0 uses it) from the token included in the request.