### PR TITLE
User handling / final features for demo

### DIFF
--- a/app/backend/user/src/main/java/de/capyclue/user/controller/UserController.java
+++ b/app/backend/user/src/main/java/de/capyclue/user/controller/UserController.java
@@ -34,11 +34,17 @@ public class UserController {
     public User getUserByAuth0Token(Authentication authentication){
         String auth0UserId = authentication.getName();
         System.out.println("auth0UserId: " + auth0UserId);
-        User user = new User();
-        user.setId("1L");
-        user.setNickname("max.mushter");
-        user.setEmail("max.mushter@email.de");
-        return user;
+        return this.userService.getUserById(auth0UserId);
+    }
+
+    @PutMapping(path = "/user")
+    public void saveUser(@RequestBody User user, Authentication authentication){
+        String auth0UserId = authentication.getName();
+        if(!auth0UserId.equals(user.getId())){
+            throw new IllegalArgumentException("user id does not match auth0 user id");
+        }
+        System.out.println("user: " + user);
+        this.userService.saveUser(user);
     }
 
 }

--- a/app/backend/user/src/main/java/de/capyclue/user/model/User.java
+++ b/app/backend/user/src/main/java/de/capyclue/user/model/User.java
@@ -39,14 +39,8 @@ public class User {
     @Column(name = "canteenHighlightingOption", nullable = true)
     private String canteenHighlightingOption;
 
-    @Column(name = "canteenShowVegetarian", nullable = true)
-    private Boolean canteenShowVegetarian;
-
-    @Column(name = "canteenShowVegan", nullable = true)
-    private Boolean canteenShowVegan;
-
-    @Column(name = "canteenShowPork", nullable = true)
-    private Boolean canteenShowPork;
+    @Column(name = "canteenFilteringOption", nullable = true)
+    private String canteenFilteringOption;
 
     public User(String id, String nickname, String email, String picture) {
         this.id = id;
@@ -57,9 +51,6 @@ public class User {
         this.canteenHighlightingActive = false;
         this.canteenHighlightingColor = "#3aac5c";
         this.canteenHighlightingOption = "vegetarian";
-        this.canteenShowVegetarian = true;
-        this.canteenShowVegan = true;
-        this.canteenShowPork = true;
     }
 
     public User() {
@@ -152,28 +143,12 @@ public class User {
         this.canteenHighlightingOption = canteenHighlightingOption;
     }
 
-    public Boolean getCanteenShowVegetarian() {
-        return canteenShowVegetarian;
+    public String getCanteenFilteringOption() {
+        return canteenFilteringOption;
     }
 
-    public void setCanteenShowVegetarian(Boolean canteenShowVegetarian) {
-        this.canteenShowVegetarian = canteenShowVegetarian;
-    }
-
-    public Boolean getCanteenShowVegan() {
-        return canteenShowVegan;
-    }
-
-    public void setCanteenShowVegan(Boolean canteenShowVegan) {
-        this.canteenShowVegan = canteenShowVegan;
-    }
-
-    public Boolean getCanteenShowPork() {
-        return canteenShowPork;
-    }
-
-    public void setCanteenShowPork(Boolean canteenShowPork) {
-        this.canteenShowPork = canteenShowPork;
+    public void setCanteenFilteringOption(String canteenFilteringOption) {
+        this.canteenFilteringOption = canteenFilteringOption;
     }
 
     @Override
@@ -184,14 +159,12 @@ public class User {
                 ", displayName='" + displayName + '\'' +
                 ", calendarTimeFormat=" + calendarTimeFormat +
                 ", calendarStandardView='" + calendarStandardView + '\'' +
-                ", calendarLink=" + calendarLink +
+                ", calendarLink='" + calendarLink + '\'' +
                 ", canteenStandardCanteen='" + canteenStandardCanteen + '\'' +
                 ", canteenHighlightingActive=" + canteenHighlightingActive +
                 ", canteenHighlightingColor='" + canteenHighlightingColor + '\'' +
                 ", canteenHighlightingOption='" + canteenHighlightingOption + '\'' +
-                ", canteenShowVegetarian=" + canteenShowVegetarian +
-                ", canteenShowVegan=" + canteenShowVegan +
-                ", canteenShowPork=" + canteenShowPork +
+                ", canteenFilteringOption='" + canteenFilteringOption + '\'' +
                 '}';
     }
 }

--- a/app/backend/user/src/main/java/de/capyclue/user/model/User.java
+++ b/app/backend/user/src/main/java/de/capyclue/user/model/User.java
@@ -16,48 +16,41 @@ public class User {
     @Column(name = "displayName", nullable = true)
     private String displayName;
 
-    @Column(name = "email", nullable = false)
-    private String email;
-
-    @Column(name = "picture", nullable = false)
-    private String picture;
-
-    @Column(name = "calendarTimeFormat", nullable = false)
+    @Column(name = "calendarTimeFormat", nullable = true)
     private Integer calendarTimeFormat;
 
-    @Column(name = "calendarStandardView", nullable = false)
+    @Column(name = "calendarStandardView", nullable = true)
     private String calendarStandardView;
 
     @Column(name = "calendarLink", nullable = true)
-    @ElementCollection(targetClass=String.class)
-    private List<String> calendarLink;
+    //@ElementCollection(targetClass=String.class)
+    //private List<String> calendarLink;
+    private String calendarLink;
 
-    @Column(name = "canteenStandardCanteen", nullable = false)
+    @Column(name = "canteenStandardCanteen", nullable = true)
     private String canteenStandardCanteen;
 
-    @Column(name = "canteenHighlightingActive", nullable = false)
+    @Column(name = "canteenHighlightingActive", nullable = true)
     private Boolean canteenHighlightingActive;
 
-    @Column(name = "canteenHighlightingColor", nullable = false)
+    @Column(name = "canteenHighlightingColor", nullable = true)
     private String canteenHighlightingColor;
 
-    @Column(name = "canteenHighlightingOption", nullable = false)
+    @Column(name = "canteenHighlightingOption", nullable = true)
     private String canteenHighlightingOption;
 
-    @Column(name = "canteenShowVegetarian", nullable = false)
+    @Column(name = "canteenShowVegetarian", nullable = true)
     private Boolean canteenShowVegetarian;
 
-    @Column(name = "canteenShowVegan", nullable = false)
+    @Column(name = "canteenShowVegan", nullable = true)
     private Boolean canteenShowVegan;
 
-    @Column(name = "canteenShowPork", nullable = false)
+    @Column(name = "canteenShowPork", nullable = true)
     private Boolean canteenShowPork;
 
     public User(String id, String nickname, String email, String picture) {
         this.id = id;
         this.nickname = nickname;
-        this.email = email;
-        this.picture = picture;
         this.calendarTimeFormat = 24;
         this.calendarStandardView = "timeGridWeek";
         this.canteenStandardCanteen = "mensa-erzbergerstrasse";
@@ -96,22 +89,6 @@ public class User {
         this.displayName = displayName;
     }
 
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPicture() {
-        return picture;
-    }
-
-    public void setPicture(String picture) {
-        this.picture = picture;
-    }
-
     public Integer getCalendarTimeFormat() {
         return calendarTimeFormat;
     }
@@ -127,7 +104,7 @@ public class User {
     public void setCalendarStandardView(String calendarStandardView) {
         this.calendarStandardView = calendarStandardView;
     }
-
+/*
     public List<String> getCalendarLink() {
         return calendarLink;
     }
@@ -135,7 +112,14 @@ public class User {
     public void setCalendarLink(List<String> calendarLink) {
         this.calendarLink = calendarLink;
     }
+*/
+    public String getCalendarLink() {
+        return calendarLink;
+    }
 
+    public void setCalendarLink(String calendarLink) {
+        this.calendarLink = calendarLink;
+    }
     public String getCanteenStandardCanteen() {
         return canteenStandardCanteen;
     }
@@ -190,5 +174,24 @@ public class User {
 
     public void setCanteenShowPork(Boolean canteenShowPork) {
         this.canteenShowPork = canteenShowPork;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id='" + id + '\'' +
+                ", nickname='" + nickname + '\'' +
+                ", displayName='" + displayName + '\'' +
+                ", calendarTimeFormat=" + calendarTimeFormat +
+                ", calendarStandardView='" + calendarStandardView + '\'' +
+                ", calendarLink=" + calendarLink +
+                ", canteenStandardCanteen='" + canteenStandardCanteen + '\'' +
+                ", canteenHighlightingActive=" + canteenHighlightingActive +
+                ", canteenHighlightingColor='" + canteenHighlightingColor + '\'' +
+                ", canteenHighlightingOption='" + canteenHighlightingOption + '\'' +
+                ", canteenShowVegetarian=" + canteenShowVegetarian +
+                ", canteenShowVegan=" + canteenShowVegan +
+                ", canteenShowPork=" + canteenShowPork +
+                '}';
     }
 }

--- a/app/backend/user/src/main/java/de/capyclue/user/service/UserService.java
+++ b/app/backend/user/src/main/java/de/capyclue/user/service/UserService.java
@@ -21,7 +21,16 @@ public class UserService implements IUserService {
     }
 
     public User getUserById(String id) {
-        return userRepository.findById(id);
+        User user = new User();
+        try {
+            user = userRepository.findById(id);
+        } catch (Exception e) {
+            System.out.println("user not found");
+        }
+        user.setCanteenShowVegetarian((user.getCanteenShowVegetarian() == null) || user.getCanteenShowVegetarian());
+        user.setCanteenShowVegan((user.getCanteenShowVegan() == null) || user.getCanteenShowVegan());
+        user.setCanteenShowPork((user.getCanteenShowPork() == null) || user.getCanteenShowPork());
+        return user;
     }
 
     public void saveUser(User user) {

--- a/app/backend/user/src/main/java/de/capyclue/user/service/UserService.java
+++ b/app/backend/user/src/main/java/de/capyclue/user/service/UserService.java
@@ -27,9 +27,6 @@ public class UserService implements IUserService {
         } catch (Exception e) {
             System.out.println("user not found");
         }
-        user.setCanteenShowVegetarian((user.getCanteenShowVegetarian() == null) || user.getCanteenShowVegetarian());
-        user.setCanteenShowVegan((user.getCanteenShowVegan() == null) || user.getCanteenShowVegan());
-        user.setCanteenShowPork((user.getCanteenShowPork() == null) || user.getCanteenShowPork());
         return user;
     }
 

--- a/app/backend/user/src/main/resources/application.properties
+++ b/app/backend/user/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.datasource.url=jdbc:mariadb://database-user:3306/dhbwcd_user
+spring.datasource.url=jdbc:mariadb://localhost:3306/dhbwcd_user
 spring.datasource.username=dummyuser
 spring.datasource.password=dummypassword
 spring.jpa.generate-ddl=true

--- a/app/backend/user/src/main/resources/application.properties
+++ b/app/backend/user/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.datasource.url=jdbc:mariadb://localhost:3306/dhbwcd_user
+spring.datasource.url=jdbc:mariadb://database-user:3306/dhbwcd_user
 spring.datasource.username=dummyuser
 spring.datasource.password=dummypassword
 spring.jpa.generate-ddl=true

--- a/app/frontend/src/components/calendar/Calendar.js
+++ b/app/frontend/src/components/calendar/Calendar.js
@@ -7,16 +7,23 @@ import interactionPlugin from '@fullcalendar/interaction'
 import rrulePlugin from '@fullcalendar/rrule'
 import bootstrap5Plugin from '@fullcalendar/bootstrap5';
 import Container from 'react-bootstrap/esm/Container';
+import { useAuth0 } from '@auth0/auth0-react';
 
 import {CalendarHttpClientContext} from '../../App';
 import { tinf21B4Rapla } from "../../config";
 
 function Calendar() {
+  const { user, isAuthenticated, getAccessTokenSilently} = useAuth0();
   const calendarHttpClient = useContext(CalendarHttpClientContext);
+  const [settings, setSettings] = useState(null);
   const [events, setEvents] = useState(null);
   useEffect(() => {
     setEvents(null);
-    calendarHttpClient.getEventsFromRapla(tinf21B4Rapla).then((ev) => {setEvents(ev); console.log(ev);});
+    calendarHttpClient.getCalendarSettings(isAuthenticated, getAccessTokenSilently).then((s) => {
+      setSettings(s);
+      let raplaUrl = (s && s.calendarLink) ? s.calendarLink : tinf21B4Rapla;
+      calendarHttpClient.getEventsFromRapla(raplaUrl).then((ev) => {setEvents(ev); console.log(ev);});
+    });
   }, []
   );
   return (

--- a/app/frontend/src/components/calendar/CalendarHttpClient.js
+++ b/app/frontend/src/components/calendar/CalendarHttpClient.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { baseUrlCalendar } from '../../config';
+import { baseUrlCalendar, baseUrlUser } from '../../config';
 
 export default class CalendarHttpClient {
 
@@ -13,5 +13,23 @@ export default class CalendarHttpClient {
                 }  
             }
             ).then((response) => response.data);
+    }
+
+    async getCalendarSettings(isAuthenticated, getAccessTokenSilently){
+        //console.log("getCanteenSettings");
+        if (!isAuthenticated) {
+            return;
+        }
+        let token = await getAccessTokenSilently();
+        //console.log(token);
+        const response = await fetch(baseUrlUser+'/user/', {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+        //console.log(response);
+        let data = await response.json();
+        //console.log(data);
+        return data;
     }
 }

--- a/app/frontend/src/components/canteen/Canteen.js
+++ b/app/frontend/src/components/canteen/Canteen.js
@@ -72,7 +72,13 @@ function Canteen(){
                                                         return true;
                                                 }
                                             })
-                                            .map((meal) => <CanteenMealCard key={meal.name} meal={meal} />)}
+                                            .map((meal) => <CanteenMealCard key={meal.name} meal={meal} highlight={
+                                                {
+                                                    "active": settings && settings.canteenHighlightingActive,
+                                                    "color": settings.canteenHighlightingColor,
+                                                    "category": settings.canteenHighlightingOption
+                                                }
+                                                } />)}
                                         </Row>
                                     </Tab>)
                                 })}

--- a/app/frontend/src/components/canteen/Canteen.js
+++ b/app/frontend/src/components/canteen/Canteen.js
@@ -30,11 +30,17 @@ function Canteen(){
     const [settings, setSettings] = useState(null);
     useEffect(() => {
         setDailyMenus(null);
-        canteenHttpClient.getCanteenSettings(isAuthenticated, getAccessTokenSilently).then((s) => setSettings(s));
-        canteenHttpClient.getWeeklyMenuOfCanteen(canteen.key).then((dm) => setDailyMenus(dm));
+        canteenHttpClient.getCanteenSettings(isAuthenticated, getAccessTokenSilently).then((s) => {
+            setSettings(s);
+            if(isAuthenticated && s && s.canteenStandardCanteen && s.canteenStandardCanteen !== canteen.key){
+                navigate('/canteen/'+s.canteenStandardCanteen);
+            }
+            canteenHttpClient.getWeeklyMenuOfCanteen(canteen.key).then((dm) => setDailyMenus(dm));
+        });
     }, [canteen.key, canteenHttpClient, whichCanteen]);
     const weekdayReference = new Date().toLocaleDateString('de-DE', { weekday: 'long', year: 'numeric', month: 'numeric', day: 'numeric' });
-    
+
+
     return(
         <Container>
             <Row>
@@ -72,11 +78,11 @@ function Canteen(){
                                                         return true;
                                                 }
                                             })
-                                            .map((meal) => <CanteenMealCard key={meal.name} meal={meal} highlight={
+                                            .map((meal) => <CanteenMealCard key={meal.name+"_"+weekday+"_"+Math.random()} meal={meal} highlight={
                                                 {
                                                     "active": settings && settings.canteenHighlightingActive,
-                                                    "color": settings.canteenHighlightingColor,
-                                                    "category": settings.canteenHighlightingOption
+                                                    "color": settings?settings.canteenHighlightingColor:"",
+                                                    "category": settings?settings.canteenHighlightingOption:""
                                                 }
                                                 } />)}
                                         </Row>

--- a/app/frontend/src/components/canteen/CanteenHttpClient.js
+++ b/app/frontend/src/components/canteen/CanteenHttpClient.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { baseUrlCanteen } from '../../config';
+import { baseUrlCanteen, baseUrlUser } from '../../config';
 
 export default class CanteenHttpClient {
 
@@ -7,5 +7,23 @@ export default class CanteenHttpClient {
         return axios.get(
             baseUrlCanteen+'/weekly/'+canteenKey
         ).then((response) => response.data);
+    }
+
+    async getCanteenSettings(isAuthenticated, getAccessTokenSilently){
+        console.log("getCanteenSettings");
+        if (!isAuthenticated) {
+            return;
+        }
+        let token = await getAccessTokenSilently();
+        console.log(token);
+        const response = await fetch(baseUrlUser+'/user/', {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+        console.log(response);
+        let data = await response.json();
+        console.log(data);
+        return data;
     }
 }

--- a/app/frontend/src/components/canteen/CanteenHttpClient.js
+++ b/app/frontend/src/components/canteen/CanteenHttpClient.js
@@ -10,20 +10,20 @@ export default class CanteenHttpClient {
     }
 
     async getCanteenSettings(isAuthenticated, getAccessTokenSilently){
-        console.log("getCanteenSettings");
+        //console.log("getCanteenSettings");
         if (!isAuthenticated) {
             return;
         }
         let token = await getAccessTokenSilently();
-        console.log(token);
+        //console.log(token);
         const response = await fetch(baseUrlUser+'/user/', {
             headers: {
                 Authorization: `Bearer ${token}`,
             },
         });
-        console.log(response);
+        //console.log(response);
         let data = await response.json();
-        console.log(data);
+        //console.log(data);
         return data;
     }
 }

--- a/app/frontend/src/components/canteen/CanteenMealCard.js
+++ b/app/frontend/src/components/canteen/CanteenMealCard.js
@@ -8,9 +8,18 @@ function CanteenMealCard(props){
     if (props.meal.name.length > 59) {
         styleOfTitle = {minHeight: '4rem', fontSize: '13pt'};
     }
+    let styleOfCard = {width: '25rem', textAlign: 'left', margin: 'auto', shadow: 'none'};
+    if (props.highlight && props.highlight.active === true && (
+        (props.highlight.category === "pork" && props.meal.meatCategory === "Schwein") ||
+        (props.highlight.category === "vegetarian" && props.meal.meatCategory === "vegetarisch") ||
+        (props.highlight.category === "vegan" && props.meal.meatCategory === "vegan")
+        )) {
+        console.log("highlight "+ props.meal.name + " with " + props.highlight.color + " because of " + props.highlight.category);
+        styleOfCard = {width: '25rem', textAlign: 'left', margin: 'auto', shadow: 'none', border: 'solid', borderColor: props.highlight.color};
+    };
     return(
         <Col>
-            <Card bg="light" className="mb-3" style={{ width: '25rem', textAlign: 'left', margin: 'auto' }}>
+            <Card bg="light" className="mb-3" style={styleOfCard}>
                 <Card.Body>
                     <Card.Title style={styleOfTitle}>{props.meal.name}</Card.Title>
                     <Badge bg="success" style={{ fontSize: '1rem' }}>{props.meal.meatCategory}</Badge>

--- a/app/frontend/src/components/canteen/CanteenMealCard.js
+++ b/app/frontend/src/components/canteen/CanteenMealCard.js
@@ -14,7 +14,6 @@ function CanteenMealCard(props){
         (props.highlight.category === "vegetarian" && props.meal.meatCategory === "vegetarisch") ||
         (props.highlight.category === "vegan" && props.meal.meatCategory === "vegan")
         )) {
-        console.log("highlight "+ props.meal.name + " with " + props.highlight.color + " because of " + props.highlight.category);
         styleOfCard = {width: '25rem', textAlign: 'left', margin: 'auto', shadow: 'none', border: 'solid', borderColor: props.highlight.color};
     };
     return(

--- a/app/frontend/src/components/settings/AccountSettings.js
+++ b/app/frontend/src/components/settings/AccountSettings.js
@@ -38,11 +38,14 @@ function AccountSettings(props) {
                             </ListGroup.Item>
                             <ListGroup.Item>{props.auth0User.email}</ListGroup.Item>
                         </ListGroup>
-                        <Button variant="primary" className="mx-1" id="saveButton" onClick={()=>handleSave(props.dbUser, props.auth0User, isAuthenticated, getAccessTokenSilently)}>Speichern</Button>
                     </Card.Body>
                 </Card>
                 </Col>
-
+            </Row>
+            <Row className="mb-3">
+                <Col className="d-flex justify-content-center">
+                <Button variant="primary" className="mx-1" id="saveButton" onClick={()=>handleSave(props.dbUser, props.auth0User, isAuthenticated, getAccessTokenSilently)}>Speichern</Button>
+                </Col>
             </Row>
            
         </Container>

--- a/app/frontend/src/components/settings/CalendarSettings.js
+++ b/app/frontend/src/components/settings/CalendarSettings.js
@@ -71,8 +71,10 @@ function CalendarSettings(props) {
                 defaultValue={props.dbUser.calendarLink}
                 />
                 </Col>
-                <Col md="1">
-                <Button type="button" onClick={()=>handleSave(props.dbUser, props.auth0User, isAuthenticated, getAccessTokenSilently)}>Speichern</Button>
+            </Row>
+            <Row className="mb-3">
+                <Col className="d-flex justify-content-center">
+                <Button variant="primary" className="mx-1" id="saveButton" onClick={()=>handleSave(props.dbUser, props.auth0User, isAuthenticated, getAccessTokenSilently)}>Speichern</Button>
                 </Col>
             </Row>
         </Container>

--- a/app/frontend/src/components/settings/CalendarSettings.js
+++ b/app/frontend/src/components/settings/CalendarSettings.js
@@ -4,8 +4,11 @@ import Col from "react-bootstrap/Col";
 import Form from 'react-bootstrap/Form';
 import FloatingLabel from "react-bootstrap/FloatingLabel";
 import Button from "react-bootstrap/Button";
+import { useAuth0 } from '@auth0/auth0-react';
+import { baseUrlUser } from '../../config';
 
 function CalendarSettings(props) {
+    const {isAuthenticated, getAccessTokenSilently} = useAuth0();
     
     return(
         <>
@@ -23,8 +26,8 @@ function CalendarSettings(props) {
                 Format: 
                 </Col>
                 <Col md="9">
-                <Form.Check type="radio" name="hourFormatRadioGroup" label="24 Stunden" defaultChecked />
-                <Form.Check type="radio" name="hourFormatRadioGroup" label="12 Stunden" />
+                <Form.Check disabled type="radio" name="hourFormatRadioGroup" label="24 Stunden" defaultChecked />
+                <Form.Check disabled type="radio" name="hourFormatRadioGroup" label="12 Stunden" />
                 </Col>
             </Row>
 
@@ -33,7 +36,7 @@ function CalendarSettings(props) {
                 Standard Ansicht: 
                 </Col>
                 <Col md="9">
-                <Form.Select>
+                <Form.Select disabled>
                     <option>Tag</option>
                     <option>Arbeitswoche</option>
                     <option>Woche</option>
@@ -49,12 +52,12 @@ function CalendarSettings(props) {
         <Container>
             <Row className="mb-3">
                 <Col>
-                <h2>Kalender hinzufügen/entfernen</h2>
+                <h2>RAPLA Kalender</h2>
                 </Col>
             </Row>
             <Row className="mb-3">
                 <Col md="3">
-                Kalender hinzufügen: 
+                RAPLA Link: 
                 </Col>
                 <Container>
                     <Row>
@@ -64,15 +67,44 @@ function CalendarSettings(props) {
                     </Row>
                 </Container>
                 <Col md="8">
-                <Form.Control type="link" placeholder="https://rapla.dhbw-karlsruhe.de/..." />
+                <Form.Control id="calendarLink" type="link" placeholder="https://rapla.dhbw-karlsruhe.de/..."
+                defaultValue={props.dbUser.calendarLink}
+                />
                 </Col>
                 <Col md="1">
-                <Button type="button" onClick="">+</Button>
+                <Button type="button" onClick={()=>handleSave(props.dbUser, props.auth0User, isAuthenticated, getAccessTokenSilently)}>Speichern</Button>
                 </Col>
             </Row>
         </Container>
         </>
     );
+}
+
+function handleSave(newDbUser, auth0User, isAuthenticated, getAccessTokenSilently) {
+    console.log("Speichern");
+    newDbUser.id = auth0User.sub;
+    newDbUser.nickname = auth0User.nickname;
+    newDbUser.email = auth0User.email;
+
+    //validate if calendarLink is valid
+    newDbUser.calendarLink = document.getElementById('calendarLink').value;
+
+    //console.log("newDbUser", newDbUser);
+    if (!isAuthenticated) {
+        return;
+    }
+    (async () => {
+    let token = await getAccessTokenSilently();
+    const response = await fetch(baseUrlUser+'/user/', {
+        method: 'PUT',
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(newDbUser)
+    });
+    //console.log("response", response);
+    })();
 }
 
 export default CalendarSettings;

--- a/app/frontend/src/components/settings/CanteenSettings.js
+++ b/app/frontend/src/components/settings/CanteenSettings.js
@@ -22,11 +22,16 @@ function CanteenSettings(props) {
     const handleHighlightingOptionChange = (e) => {
         setHighlightingOption(e.target.value);
     };
+    const [filteringOption, setFilteringOption] = useState(props.dbUser.canteenFilteringOption || 'all');
+    const handleFilteringOptionChange = (e) => {
+        setFilteringOption(e.target.value);
+    };
     useEffect(() => {
         setColor(props.dbUser.canteenHighlightingColor);
         setCanteen(props.dbUser.canteenStandardCanteen);
         setHighlightingOption(props.dbUser.canteenHighlightingOption);
-    }, [props.dbUser.canteenHighlightingColor, props.dbUser.canteenStandardCanteen, props.dbUser.canteenHighlightingOption]);
+        setFilteringOption(props.dbUser.canteenFilteringOption);
+    }, [props.dbUser.canteenHighlightingColor, props.dbUser.canteenStandardCanteen, props.dbUser.canteenHighlightingOption, props.dbUser.canteenFilteringOption]);
    
     return(
         <>
@@ -98,12 +103,15 @@ function CanteenSettings(props) {
 
             <Row className="mb-3">
                 <Col md="3">
-                <Form.Label>Gerichte anzeigen mit Eigenschaft:</Form.Label>
+                <Form.Label>Gerichte anzeigen mit Mindesteigenschaft:</Form.Label>
                 </Col>
                 <Col md="9">
-                <Form.Check id="canteenShowVegetarian" defaultChecked={props.dbUser.canteenShowVegetarian} type="checkbox" label="vegetarisch"  />
-                <Form.Check id="canteenShowVegan" defaultChecked={props.dbUser.canteenShowVegan} type="checkbox" label="vegan"  />
-                <Form.Check id="canteenShowPork" defaultChecked={props.dbUser.canteenShowPork} type="checkbox" label="Schweinefleisch" />
+                <Form.Select id="filteringOptionSelect" value={filteringOption} onChange={handleFilteringOptionChange}>
+                    <option value="all">Alle Anzeigen</option>
+                    <option value="nopork">Kein Schweinefleisch</option>
+                    <option value="vegetarian">vegetarisch</option>
+                    <option value="vegan">vegan</option>
+                </Form.Select>
                 </Col>
             </Row>
             <Row className="mb-3">
@@ -125,9 +133,7 @@ function handleSave(newDbUser, auth0User, isAuthenticated, getAccessTokenSilentl
     newDbUser.canteenHighlightingActive = document.getElementById("highlightingCheck").checked;
     newDbUser.canteenHighlightingColor = document.getElementById("highlightingColorSelect").value;
     newDbUser.canteenHighlightingOption = document.getElementById("highlightingOptionSelect").value;
-    newDbUser.canteenShowVegetarian = document.getElementById("canteenShowVegetarian").checked;
-    newDbUser.canteenShowVegan = document.getElementById("canteenShowVegan").checked;
-    newDbUser.canteenShowPork = document.getElementById("canteenShowPork").checked;
+    newDbUser.canteenFilteringOption = document.getElementById("filteringOptionSelect").value;
 
 
     //console.log("newDbUser", newDbUser);

--- a/app/frontend/src/components/settings/CanteenSettings.js
+++ b/app/frontend/src/components/settings/CanteenSettings.js
@@ -1,32 +1,33 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Form from 'react-bootstrap/Form';
+import { useAuth0 } from '@auth0/auth0-react';
+import { baseUrlUser } from '../../config';
+import Button from 'react-bootstrap/esm/Button';
 
 function CanteenSettings(props) {
-
-    const [mealShowCheck, setMealShowCheck] = useState(true); //
-
-    const handleMealShowCheckChange = event => {
-        setMealShowCheck(!mealShowCheck);
-
-    }
-
-    const [highlightingCheck, setHighlightingCheck] = useState(false);
-
-    const handleHighlightingCheckChange = event => {
-        setHighlightingCheck(!highlightingCheck);
-    }
-
-    const [highlightingColor, setHighlightingColor] = useState("#3aac5c"); //Change the useState-Value to user's last saved settings
-
-    const handleHighlightingColorChange = event => {
-        setHighlightingColor(event.target.value);
-        console.log(highlightingColor);
-    }
-
+    const {isAuthenticated, getAccessTokenSilently} = useAuth0();
+    const [canteen, setCanteen] = useState(props.dbUser.canteenStandardCanteen || 'mensa-erzbergerstrasse');
+    const handleCanteenChange = (e) => {
+        setCanteen(e.target.value);
+    };
+    const [color, setColor] = useState(props.dbUser.canteenHighlightingColor || 'green');
+    const handleColorChange = (e) => {
+        setColor(e.target.value);
+    };
+    const [highlightingOption, setHighlightingOption] = useState(props.dbUser.canteenHighlightingOption || 'vegetarian');
+    const handleHighlightingOptionChange = (e) => {
+        setHighlightingOption(e.target.value);
+    };
+    useEffect(() => {
+        setColor(props.dbUser.canteenHighlightingColor);
+        setCanteen(props.dbUser.canteenStandardCanteen);
+        setHighlightingOption(props.dbUser.canteenHighlightingOption);
+    }, [props.dbUser.canteenHighlightingColor, props.dbUser.canteenStandardCanteen, props.dbUser.canteenHighlightingOption]);
+   
     return(
         <>
         <h1>Mensa-Einstellungen</h1>
@@ -42,10 +43,10 @@ function CanteenSettings(props) {
                 Meine Mensa: 
                 </Col>
                 <Col md="9">
-                <Form.Select>
-                    <option>Mensa Erzbergerstraße</option>
-                    <option>Mensa am Adenauerring</option>
-                    <option>Mensa Moltke</option>
+                <Form.Select id="canteenStandardCanteen" value={canteen} onChange={handleCanteenChange}>
+                    <option value="mensa-erzbergerstrasse">Mensa Erzbergerstraße</option>
+                    <option value="mensa-am-adenauerring">Mensa am Adenauerring</option>
+                    <option value="mensa-moltke">Mensa Moltke</option>
                 </Form.Select>
                 </Col>
             </Row>
@@ -54,21 +55,20 @@ function CanteenSettings(props) {
                 <Form.Label>Highlighting aktivieren: </Form.Label>
                 </Col>
                 <Col md="9">
-                <Form.Check className="" type="checkbox" onChange={handleHighlightingCheckChange} id="" aria-label="activate Highlighting" />
+                <Form.Check defaultChecked={props.dbUser.canteenHighlightingActive} className="" type="checkbox" id="highlightingCheck" aria-label="activate Highlighting" />
                 </Col>
             </Row>
-
-            {/* Show following Options only when Checkbox is checked */}
-            {/* add Check for user's saved settings */}
-            { highlightingCheck ?
-
-            <>
             <Row className="mb-3">
                 <Col md="3">
                 <Form.Label>Highlighting-Farbe: </Form.Label>
                 </Col>
                 <Col md="9">
-                <Form.Control type="color" defaultValue={highlightingColor} title="Color Picker" id="highlightingColorPicker" onChange={handleHighlightingColorChange} />
+                <Form.Select id="highlightingColorSelect" value={color} onChange={handleColorChange}>
+                    <option value="green">grün</option>
+                    <option value="yellow">gelb</option>
+                    <option value="red">rot</option>
+                    <option value="blue">blau</option>
+                </Form.Select>
                 </Col>
             </Row>
 
@@ -77,16 +77,13 @@ function CanteenSettings(props) {
                 <Form.Label>Highlighting-Typen: </Form.Label>
                 </Col>
                 <Col md="9">
-                <Form.Select>
-                    <option>vegetarisch</option>
-                    <option>vegan</option>
-                    <option>Schweinefleisch</option>
+                <Form.Select id="highlightingOptionSelect" value={highlightingOption} onChange={handleHighlightingOptionChange}>
+                    <option value="vegetarian">vegetarisch</option>
+                    <option value="vegan">vegan</option>
+                    <option value="pork">Schweinefleisch</option>
                 </Form.Select>
                 </Col>
             </Row>
-            </>
-            
-            : null}
 
         </Container>
 
@@ -104,14 +101,51 @@ function CanteenSettings(props) {
                 <Form.Label>Gerichte anzeigen mit Eigenschaft:</Form.Label>
                 </Col>
                 <Col md="9">
-                <Form.Check type="checkbox" label="vegetarisch" checked={mealShowCheck} onChange={handleMealShowCheckChange} />
-                <Form.Check type="checkbox" label="vegan" checked={mealShowCheck} onChange={handleMealShowCheckChange} />
-                <Form.Check type="checkbox" label="Schweinefleisch" checked={mealShowCheck} onChange={handleMealShowCheckChange} />
+                <Form.Check id="canteenShowVegetarian" defaultChecked={props.dbUser.canteenShowVegetarian} type="checkbox" label="vegetarisch"  />
+                <Form.Check id="canteenShowVegan" defaultChecked={props.dbUser.canteenShowVegan} type="checkbox" label="vegan"  />
+                <Form.Check id="canteenShowPork" defaultChecked={props.dbUser.canteenShowPork} type="checkbox" label="Schweinefleisch" />
                 </Col>
+            </Row>
+            <Row className="mb-3">
+                <Col md="3">
+                    <Button variant="primary" onClick={() => handleSave(props.dbUser, props.auth0User, isAuthenticated, getAccessTokenSilently)}>Speichern</Button>
+                </Col>    
             </Row>
         </Container>
         </>
     );
+}
+
+function handleSave(newDbUser, auth0User, isAuthenticated, getAccessTokenSilently) {
+    console.log("Speichern");
+    newDbUser.id = auth0User.sub;
+    newDbUser.nickname = auth0User.nickname;
+    newDbUser.email = auth0User.email;
+    newDbUser.canteenStandardCanteen = document.getElementById("canteenStandardCanteen").value;
+    newDbUser.canteenHighlightingActive = document.getElementById("highlightingCheck").checked;
+    newDbUser.canteenHighlightingColor = document.getElementById("highlightingColorSelect").value;
+    newDbUser.canteenHighlightingOption = document.getElementById("highlightingOptionSelect").value;
+    newDbUser.canteenShowVegetarian = document.getElementById("canteenShowVegetarian").checked;
+    newDbUser.canteenShowVegan = document.getElementById("canteenShowVegan").checked;
+    newDbUser.canteenShowPork = document.getElementById("canteenShowPork").checked;
+
+
+    //console.log("newDbUser", newDbUser);
+    if (!isAuthenticated) {
+        return;
+    }
+    (async () => {
+    let token = await getAccessTokenSilently();
+    const response = await fetch(baseUrlUser+'/user/', {
+        method: 'PUT',
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(newDbUser)
+    });
+    //console.log("response", response);
+    })();
 }
 
 export default CanteenSettings;

--- a/app/frontend/src/components/settings/CanteenSettings.js
+++ b/app/frontend/src/components/settings/CanteenSettings.js
@@ -107,9 +107,9 @@ function CanteenSettings(props) {
                 </Col>
             </Row>
             <Row className="mb-3">
-                <Col md="3">
-                    <Button variant="primary" onClick={() => handleSave(props.dbUser, props.auth0User, isAuthenticated, getAccessTokenSilently)}>Speichern</Button>
-                </Col>    
+                <Col className="d-flex justify-content-center">
+                <Button variant="primary" className="mx-1" id="saveButton" onClick={()=>handleSave(props.dbUser, props.auth0User, isAuthenticated, getAccessTokenSilently)}>Speichern</Button>
+                </Col>
             </Row>
         </Container>
         </>

--- a/app/frontend/src/components/settings/Settings.js
+++ b/app/frontend/src/components/settings/Settings.js
@@ -45,7 +45,7 @@ function Settings() {
                     <Nav.Link eventKey="account">Account</Nav.Link>
                     <Nav.Link eventKey="calendar">Kalender</Nav.Link>
                     <Nav.Link eventKey="canteen">Mensa</Nav.Link>
-                    <Nav.Link eventKey="general">Allgemein</Nav.Link>
+                    {/*<Nav.Link eventKey="general">Allgemein</Nav.Link>*/}
                     <Nav.Link eventKey="about">Über</Nav.Link>
                 </Nav>
                 
@@ -55,13 +55,13 @@ function Settings() {
                 {/* contents of different settings pages */}
                 <Tab.Content>
                     <Tab.Pane eventKey="account">
-                        <AccountSettings />
+                        <AccountSettings auth0User={user} dbUser={userData}  />
                     </Tab.Pane>
                     <Tab.Pane eventKey="calendar">
-                        <CalendarSettings />
+                        <CalendarSettings auth0User={user} dbUser={userData} />
                     </Tab.Pane>
                     <Tab.Pane eventKey="canteen">
-                        <CanteenSettings />
+                        <CanteenSettings auth0User={user} dbUser={userData} />
                     </Tab.Pane>
                     <Tab.Pane eventKey="general">
                         <GeneralSettings />


### PR DESCRIPTION
I added:

- Retrieving the own (auth0Id) user from backend, if no user return an empty / default object
- Add save buttons to each Settings Component that read the value of the input/select/checkbox/..., update those values in the "dbUser", then send ("PUT") the updated object to the backend.
- Some changes to the User.java: Made most fields nullable so that the Database can handle only partially filled settings
- Add some checks in the backend to make sure a user can only update their own settings.

Open as of creating the PR-Draft:

- [x] Get and use the RAPLA url set by the user in the Calendar
- [x] Get and use the default canteen set by the user in Canteen
- [x] Get and use the canteen highlighting set by the user in Canteen
- [x] Get and use the meal type filters set by the user in Canteen